### PR TITLE
chore: use source from branch 'freeze/v2025.1'

### DIFF
--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,7 +16,7 @@ RUN apt-get update && \
     && rm -rf /var/lib/apt/lists/*
 
 # Clone GROMACS repository (this layer will be cached unless the repo changes)
-RUN git clone -b devel https://github.com/rrandiak/gromacs.git /gromacs
+RUN git clone -b freeze/v2025.1 https://github.com/rrandiak/gromacs.git /gromacs
 
 # Build GROMACS (this layer will be cached unless the source code changes)
 WORKDIR /gromacs


### PR DESCRIPTION
Hello,

I’ve rebased the TPR serializable `gmx dump` tool onto the official GROMACS `v2025.1` release commit. The updated implementation is available in a dedicated branch: [freeze/v2025.1](https://github.com/rrandiak/gromacs/tree/freeze/v2025.1). 

The tool was tested on a set of approximately 100 TPR files, and I also visually compared the code of the original text-based implementation and the new serializable version.

If issues are discovered during unit test development (which hopefully would be done soon), I will create a new branch to address them without altering this one.

I also tested building and running using `docker compose`.

cc: @rosinec 